### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
-RichHttpServer	        KEYWORD1
+RichHttpServer	KEYWORD1
 
-onAuthenticated         KEYWORD2
-onPatternAuthenticated  KEYWORD2
-onPattern               KEYWORD2
-requireAuthentication   KEYWORD2
-disableAuthentication   KEYWORD2
-isAuthenticationEnabled KEYWORD2
-isClientConnected       KEYWORD2
+onAuthenticated	KEYWORD2
+onPatternAuthenticated	KEYWORD2
+onPattern	KEYWORD2
+requireAuthentication	KEYWORD2
+disableAuthentication	KEYWORD2
+isAuthenticationEnabled	KEYWORD2
+isClientConnected	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords